### PR TITLE
Pick Python3 from the environment

### DIFF
--- a/video2hls
+++ b/video2hls
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """Convert a video into a set of files to play it using HLS.
 


### PR DESCRIPTION
Pick Python3 from the environment instead of hard-coding a path which may not exist for everyone.